### PR TITLE
[Preview] upgrade to ocamlformat.0.20.0

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,2 @@
-version = 0.19.0
+version = 0.20.0
+profile = conventional

--- a/bin/file.ml
+++ b/bin/file.ml
@@ -33,7 +33,6 @@ let pp_error ppf = function
   | `Not_found -> Format.fprintf ppf "Not found"
 
 let mime = ref false
-
 let filename = ref None
 
 let anonymous_argument v =
@@ -51,7 +50,6 @@ let spec =
   ]
 
 let exit_success = 0
-
 let exit_failure = 1
 
 let () =

--- a/bin/serialize.ml
+++ b/bin/serialize.ml
@@ -1,7 +1,5 @@
 let name = ref "conan_database.ml"
-
 let ( / ) = Filename.concat
-
 let identity x = x
 
 let ocamlify s =
@@ -137,11 +135,8 @@ let dry_run only_mime database output =
   List.iter (Format.printf "%s\n%!") ((output / !name) :: files)
 
 let database = ref None
-
 let output = ref None
-
 let dry_run_flag = ref false
-
 let only_mime_flag = ref false
 
 let anonymous_argument v =
@@ -174,7 +169,6 @@ let spec =
   ]
 
 let exit_success = 0
-
 let exit_failure = 1
 
 let () =

--- a/light/generate.ml
+++ b/light/generate.ml
@@ -56,7 +56,6 @@ let run database output =
   close_out oc
 
 let database = ref None
-
 let output = ref None
 
 let anonymous_argument v =
@@ -73,7 +72,6 @@ let spec =
   ]
 
 let exit_success = 0
-
 let exit_failure = 1
 
 let () =

--- a/lwt/conan_lwt.ml
+++ b/lwt/conan_lwt.ml
@@ -6,13 +6,11 @@ end) : sig
   type t
 
   val prj : ('a, t) io -> 'a S.t
-
   val inj : 'a S.t -> ('a, t) io
 end = struct
   type t
 
   external prj : ('a, t) io -> 'a S.t = "%identity"
-
   external inj : 'a S.t -> ('a, t) io = "%identity"
 end
 
@@ -29,9 +27,7 @@ let lwt =
   { bind; return = (fun x -> inj (Lwt.return x)) }
 
 external get_uint16 : string -> int -> int = "%caml_string_get16"
-
 external get_uint32 : string -> int -> int32 = "%caml_string_get32"
-
 external get_uint64 : string -> int -> int64 = "%caml_string_get64"
 
 module Stream = struct

--- a/src/arithmetic.ml
+++ b/src/arithmetic.ml
@@ -79,21 +79,13 @@ let is = function
   | _ -> false
 
 let add v = Add v
-
 let sub v = Sub v
-
 let mul v = Mul v
-
 let div v = Div v
-
 let rem v = Mod v
-
 let logand v = Bitwise_and v
-
 let logxor v = Bitwise_xor v
-
 let invert v = Invert v
-
 let logor v = Bitwise_or v
 
 let rec process : type a. ?unsigned:bool -> a Integer.t -> a -> a t -> a =

--- a/src/arithmetic.mli
+++ b/src/arithmetic.mli
@@ -13,35 +13,19 @@ val serialize :
   (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
 
 val pp : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
-
 val map : f:('a -> 'b) -> 'a t -> 'b t
-
 val value : 'a t -> 'a
-
 val of_string : with_val:'a -> string -> 'a t
-
 val is : char -> bool
-
 val add : 'a -> 'a t
-
 val sub : 'a -> 'a t
-
 val div : 'a -> 'a t
-
 val rem : 'a -> 'a t
-
 val mul : 'a -> 'a t
-
 val logand : 'a -> 'a t
-
 val logxor : 'a -> 'a t
-
 val logor : 'a -> 'a t
-
 val invert : 'a t -> 'a t
-
 val process : ?unsigned:bool -> 'a Integer.t -> 'a -> 'a t -> 'a
-
 val process_float : float -> float t -> float
-
 val process_ptime : Ptime.Span.t -> Ptime.Span.t t -> Ptime.Span.t

--- a/src/comparison.ml
+++ b/src/comparison.ml
@@ -19,15 +19,10 @@ let serialize pp ppf = function
   | Xor v -> Format.fprintf ppf "@[<2>Conan.Comparison.bitwise_xor@ %a@]" pp v
 
 let equal_to v = Equal v
-
 let different_to v = Different v
-
 let greater_than v = Greater v
-
 let lower_than v = Lower v
-
 let bitwise_and v = And v
-
 let bitwise_xor v = Xor v
 
 let of_string ~with_val = function

--- a/src/comparison.mli
+++ b/src/comparison.mli
@@ -4,31 +4,17 @@ val serialize :
   (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
 
 val pp : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
-
 val of_string : with_val:'a -> string -> 'a t
-
 val is : char -> bool
-
 val map : f:('a -> 'b) -> 'a t -> 'b t
-
 val value : 'a t -> 'a
-
 val equal_to : 'a -> 'a t
-
 val different_to : 'a -> 'a t
-
 val greater_than : 'a -> 'a t
-
 val lower_than : 'a -> 'a t
-
 val bitwise_and : 'a -> 'a t
-
 val bitwise_xor : 'a -> 'a t
-
 val process : 'a Integer.t -> 'a -> 'a t -> bool
-
 val process_float : float -> float t -> bool
-
 val process_string : string -> string t -> bool
-
 val process_ptime : Ptime.Span.t -> Ptime.Span.t t -> bool

--- a/src/fmt.ml
+++ b/src/fmt.ml
@@ -4,7 +4,6 @@
    with [Hmap]. See [Atom]. *)
 
 type ('a, 'b) refl = Refl : ('a, 'a) refl
-
 type formatter = Format.formatter
 
 module Hmap = struct
@@ -14,7 +13,6 @@ module Hmap = struct
 
   module type Tid = sig
     type t
-
     type _ Tid.t += Tid : t Tid.t
   end
 
@@ -23,7 +21,6 @@ module Hmap = struct
   let tid () (type s) =
     let module M = struct
       type t = s
-
       type _ Tid.t += Tid : t Tid.t
     end in
     (module M : Tid with type t = s)
@@ -51,9 +48,7 @@ module Hmap = struct
     type t = V : 'a key -> t
 
     let hide_type k = V k
-
     let equal (V k0) (V k1) = (compare : int -> int -> int) k0.uid k1.uid = 0
-
     let compare (V k0) (V k1) = (compare : int -> int -> int) k0.uid k1.uid
   end
 
@@ -74,7 +69,6 @@ module Hmap = struct
   type t = binding Map.t
 
   let empty = Map.empty
-
   let add k v t = Map.add (V k) (B (k, v)) t
 
   let find :
@@ -181,18 +175,15 @@ and ('ty0, 'v0, 'ty1, 'v1) tyrel =
   | End : ('v0, 'v0, 'v1, 'v1) tyrel
 
 type ('v, 'r) tw = T : ('u, 'v) fmt * ('v, 'w) ty -> ('u, 'w) tw
-
 type ('v, 'r) pw = P : ('u, 'v) padding * ('v, 'w) ty -> ('u, 'w) pw
 
 type ('v, 'r) ppw =
   | V : ('a, 'b) padding * ('b, 'c) precision * ('c, 'd) ty -> ('a, 'd) ppw
 
 type v = Fmt : ('ty, 'v) fmt -> v
-
 type w = Ty : ('ty, 'v) ty -> w
 
 let pf = Format.fprintf
-
 let strf = Format.asprintf
 
 let padding_and_precision_to_padding :
@@ -310,7 +301,6 @@ let rec ty_of_fmt : type v r. (v, r) fmt -> (v, r) ty = function
       padding @ String (ty_of_fmt fmt)
 
 exception Invalid_type
-
 exception Invalid_key
 
 let gen_padding :
@@ -459,21 +449,15 @@ let pp_string ?padding ppf v =
   | _ -> pf ppf "%s" v
 
 type wpd = Pd : ('v, 'r) padding -> wpd
-
 type wpr = Pr : ('v, 'r) precision -> wpr
 
 let is_flag = function '-' | '0' | '#' -> true | _ -> false
-
 let is_dash = function '-' -> true | _ -> false
-
 let is_zero = function '0' -> true | _ -> false
-
 let is_digit = function '0' .. '9' -> true | _ -> false
-
 let is_hash = function '#' -> true | _ -> false
 
 type s = Sub.t
-
 type 'r ebb = Ebb : ('x, 'r) fmt -> 'r ebb
 
 type ('x, 'r) pdebb =
@@ -639,11 +623,8 @@ let ty_of_string : type x. any:x Hmap.key -> string -> w =
   Ty (ty_of_fmt fmt)
 
 let noop : _ order = Noop
-
 let ignore : _ order = Ignore
-
 let const pp v = Const (pp, v)
-
 let ( $ ) = const
 
 let padding = function

--- a/src/integer.ml
+++ b/src/integer.ml
@@ -14,13 +14,9 @@ let serializer_of : type a. a t -> Format.formatter -> a -> unit = function
   | Int64 -> Serialize.int64
 
 let byte = Byte
-
 let short = Short
-
 let int32 = Int32
-
 let int64 = Int64
-
 let pf = Format.fprintf
 
 let pp : type a. a t -> Format.formatter -> a -> unit = function

--- a/src/integer.mli
+++ b/src/integer.mli
@@ -5,45 +5,25 @@ type 'a t = private
   | Int64 : int64 t
 
 val serialize : Format.formatter -> 'a t -> unit
-
 val serializer_of : 'a t -> Format.formatter -> 'a -> unit
-
 val byte : char t
-
 val short : int t
-
 val int32 : int32 t
-
 val int64 : int64 t
-
 val pp : 'a t -> Format.formatter -> 'a -> unit
-
 val add : 'a t -> 'a -> 'a -> 'a
-
 val sub : 'a t -> 'a -> 'a -> 'a
-
 val mul : 'a t -> 'a -> 'a -> 'a
-
 val div : ?unsigned:bool -> 'a t -> 'a -> 'a -> 'a
-
 val rem : ?unsigned:bool -> 'a t -> 'a -> 'a -> 'a
-
 val bitwise_and : 'a t -> 'a -> 'a -> 'a
-
 val bitwise_xor : 'a t -> 'a -> 'a -> 'a
-
 val bitwise_or : 'a t -> 'a -> 'a -> 'a
-
 val invert : 'a t -> 'a -> 'a
-
 val greater : 'a t -> 'a -> 'a -> bool
-
 val lower : 'a t -> 'a -> 'a -> bool
-
 val equal : 'a t -> 'a -> 'a -> bool
-
 val different : 'a t -> 'a -> 'a -> bool
-
 val zero : 'a t -> 'a
 
 val parse :

--- a/src/metadata.ml
+++ b/src/metadata.ml
@@ -24,11 +24,8 @@ let with_output output t =
   else t
 
 let output { output; _ } = output
-
 let clear { mime; _ } = { output = None; mime }
-
 let mime { mime; _ } = mime
-
 let empty = { output = None; mime = None }
 
 let concat a0 a1 =

--- a/src/metadata.mli
+++ b/src/metadata.mli
@@ -1,17 +1,10 @@
 type t
 
 val pp : Format.formatter -> t -> unit
-
 val with_mime : string -> t -> t
-
 val with_output : string -> t -> t
-
 val clear : t -> t
-
 val output : t -> string option
-
 val mime : t -> string option
-
 val concat : t -> t -> t
-
 val empty : t

--- a/src/number.ml
+++ b/src/number.ml
@@ -1,7 +1,6 @@
 type t = Int of int64 | Float of float
 
 let int64 v = Int v
-
 let float v = Float v
 
 let pp ppf = function
@@ -12,7 +11,6 @@ let to_float = function Int v -> Int64.to_float v | Float v -> v
 
 (* TODO(dinosaure): check with 32bits/64bits platform. *)
 let to_int = function Int v -> Int64.to_int v | Float v -> Float.to_int v
-
 let to_int64 = function Int v -> v | Float v -> Int64.of_float v
 
 let to_int32 = function

--- a/src/number.mli
+++ b/src/number.mli
@@ -1,23 +1,13 @@
 type t
 
 val int64 : int64 -> t
-
 val float : float -> t
-
 val pp : Format.formatter -> t -> unit
-
 val to_float : t -> float
-
 val to_int : t -> int
-
 val to_int64 : t -> int64
-
 val to_int32 : t -> int32
-
 val to_short : t -> int
-
 val to_byte : t -> char
-
 val to_ptime : t -> Ptime.Span.t
-
 val parse : Sub.t -> (t * Sub.t, [> `Empty | `Invalid_number of string ]) result

--- a/src/offset.ml
+++ b/src/offset.ml
@@ -1,5 +1,4 @@
 let ( <.> ) f g x = f (g x)
-
 let ok x = Ok x
 
 type t =

--- a/src/offset.mli
+++ b/src/offset.mli
@@ -6,7 +6,6 @@ type t =
   | Calculation of t * t Arithmetic.t
 
 val serialize : Format.formatter -> t -> unit
-
 val pp : Format.formatter -> t -> unit
 
 open Sigs

--- a/src/parse.ml
+++ b/src/parse.ml
@@ -8,55 +8,34 @@ let string_tail s =
   if String.length s > 0 then String.sub s 1 (String.length s - 1) else ""
 
 let ( >>= ) x f = match x with Ok x -> f x | Error err -> Error err
-
 let ( >|= ) x f = match x with Ok x -> Ok (f x) | Error err -> Error err
-
 let ( <.> ) f g x = f (g x)
 
 open Sub
 
 let is_wsp = function ' ' | '\t' .. '\r' -> true | _ -> false
-
 let is_digit = function '0' .. '9' -> true | _ -> false
-
 let is_greater = function '>' -> true | _ -> false
-
 let is_ampersand = function '&' -> true | _ -> false
-
 let is_c = function 'c' -> true | _ -> false
-
 let is_C = function 'C' -> true | _ -> false
-
 let is_b = function 'b' -> true | _ -> false
-
 let is_B = function 'B' -> true | _ -> false
-
 let is_s = function 's' -> true | _ -> false
-
 let is_r = function 'r' -> true | _ -> false
-
 let is_l = function 'l' -> true | _ -> false
-
 let is_t = function 't' -> true | _ -> false
-
 let is_T = function 'T' -> true | _ -> false
-
 let is_w = function 'w' -> true | _ -> false
-
 let is_W = function 'W' -> true | _ -> false
 
 let lparent = v "("
-
 and rparent = v ")"
 
 let ampersand = v "&"
-
 let tilde = v "~"
-
 let dot = v "."
-
 let u = v "u"
-
 let slash = v "/"
 
 let parse_disp s =
@@ -119,47 +98,27 @@ let prefix ~affix s =
   | None -> Error (`No_prefix (affix, s))
 
 let le = v "le"
-
 and be = v "be"
-
 and me = v "me"
 
 let byte = v "byte"
-
 and long = v "long"
-
 and quad = v "quad"
-
 and date = v "date"
-
 and clear = v "clear"
-
 and short = v "short"
-
 and ldate = v "ldate"
-
 and regex = v "regex"
-
 and qdate = v "qdate"
-
 and float = v "float"
-
 and double = v "double"
-
 and qldate = v "qldate"
-
 and qwdate = v "qwdate"
-
 and search = v "search"
-
 and string = v "string"
-
 and pstring = v "pstring"
-
 and default = v "default"
-
 and indirect = v "indirect"
-
 and offset = v "offset"
 
 let _16 = v "16"
@@ -178,7 +137,6 @@ type numeric =
   | `Float ]
 
 type default = [ `Default ]
-
 type regex = [ `Regex ]
 
 let parse_type s =
@@ -411,7 +369,6 @@ let parse_use offset s =
   else Error `Invalid_use_command
 
 let hws = v "\t"
-
 let wsp = v " "
 
 type rule = offset * kind * test * message

--- a/src/parse.mli
+++ b/src/parse.mli
@@ -72,7 +72,5 @@ type error =
   | `Invalid_use_command ]
 
 val pp_error : Format.formatter -> error -> unit
-
 val parse_line : string -> (line, error) result
-
 val parse_in_channel : in_channel -> (line list, [> error ]) result

--- a/src/process.ml
+++ b/src/process.ml
@@ -1,5 +1,4 @@
 let invalid_arg fmt = Format.kasprintf invalid_arg fmt
-
 let reword_error f = function Ok _ as v -> v | Error err -> Error (f err)
 
 open Sigs

--- a/src/process.mli
+++ b/src/process.mli
@@ -17,7 +17,5 @@ val ascending_walk :
   (Metadata.t list, 't) io
 
 val database : tree:Tree.t -> database
-
 val append : tree:Tree.t -> database -> database
-
 val only_mime_paths : database -> Tree.t

--- a/src/ropes.ml
+++ b/src/ropes.ml
@@ -1,7 +1,6 @@
 type t = Str of string * int * int | App of t * t * int * int
 
 let empty = ""
-
 let empty = Str (empty, 0, 0)
 
 let of_string ?(off = 0) ?len str =
@@ -11,7 +10,6 @@ let of_string ?(off = 0) ?len str =
   Str (str, off, len)
 
 let length = function Str (_, _, len) -> len | App (_, _, len, _) -> len
-
 let height = function Str _ -> 0 | App (_, _, _, height) -> height
 
 let app = function

--- a/src/serialize.ml
+++ b/src/serialize.ml
@@ -1,9 +1,7 @@
 type 'a t = Format.formatter -> 'a -> unit
 
 let cut ppf _ = Format.pp_print_cut ppf ()
-
 let fmt fmt ppf = Format.fprintf ppf fmt
-
 let char ppf chr = Format.fprintf ppf "'\\%03d'" (Char.code chr)
 
 let int ppf n =
@@ -43,7 +41,6 @@ let surround s0 s1 pp ppf v =
     pp_print_string ppf s1)
 
 let brackets pp = box ~indent:1 (surround "[" "]" pp)
-
 let parens pp = box ~indent:1 (surround "(" ")" pp)
 
 let iter ?sep:(pp_sep = cut) iter pp ppf v =
@@ -59,7 +56,6 @@ let ( ++ ) pp0 pp1 ppf v =
   pp1 ppf v
 
 let using f pp ppf v = pp ppf (f v)
-
 let list ?sep pp = iter ?sep List.iter pp
 
 let semi ppf _ =
@@ -71,7 +67,6 @@ let comma ppf _ =
   Format.pp_print_space ppf ()
 
 let list pp = brackets (list ~sep:semi (box pp))
-
 let pair pp0 pp1 = parens (using fst (box pp0) ++ comma ++ using snd (box pp1))
 
 module Re_serialize = struct
@@ -99,23 +94,14 @@ module Re_serialize = struct
       j
 
   and beg_of_line ppf () = Format.pp_print_string ppf "Re.bol"
-
   and end_of_line ppf () = Format.pp_print_string ppf "Re.eol"
-
   and beg_of_word ppf () = Format.pp_print_string ppf "Re.bow"
-
   and end_of_word ppf () = Format.pp_print_string ppf "Re.eow"
-
   and not_bound ppf () = Format.pp_print_string ppf "Re.not_boundary"
-
   and beg_of_str ppf () = Format.pp_print_string ppf "Re.bos"
-
   and end_of_str ppf () = Format.pp_print_string ppf "Re.eos"
-
   and last_end_of_line ppf () = Format.pp_print_string ppf "Re.leol"
-
   and start ppf () = Format.pp_print_string ppf "Re.start"
-
   and stop ppf () = Format.pp_print_string ppf "Re.stop"
 
   and sem ppf (sem, t) =
@@ -137,7 +123,6 @@ module Re_serialize = struct
     Format.fprintf ppf "@[<2>Re.no_group @[%a@]@]" (parens view) t
 
   and nest ppf t = Format.fprintf ppf "@[<2>Re.nest @[%a@]@]" (parens view) t
-
   and case ppf t = Format.fprintf ppf "@[<2>Re.case @[%a@]@]" (parens view) t
 
   and no_case ppf t =

--- a/src/serialize.mli
+++ b/src/serialize.mli
@@ -1,29 +1,16 @@
 type 'a t = Format.formatter -> 'a -> unit
 
 val cut : _ t
-
 val fmt : ('a, Format.formatter, unit) format -> Format.formatter -> 'a
-
 val char : char t
-
 val int : int t
-
 val int32 : int32 t
-
 val int64 : int64 t
-
 val float : float t
-
 val string : string t
-
 val pair : 'a t -> 'b t -> ('a * 'b) t
-
 val option : 'a t -> 'a option t
-
 val parens : 'a t -> 'a t
-
 val ptime_span : Ptime.Span.t t
-
 val re : Re.t t
-
 val list : 'a t -> 'a list t

--- a/src/size.ml
+++ b/src/size.ml
@@ -1,7 +1,5 @@
 let invalid_arg fmt = Format.kasprintf invalid_arg fmt
-
 let ( <.> ) f g x = f (g x)
-
 let ok x = Ok x
 
 type t =
@@ -29,31 +27,18 @@ let serialize ppf = function
   | Bequad -> Format.pp_print_string ppf "Conan.Size.bequad"
 
 let byte = Byte
-
 let leshort = Leshort
-
 let beshort = Beshort
-
 let lelong = Lelong
-
 let belong = Belong
-
 let melong = Melong
-
 let leid3 = Leid3
-
 let beid3 = Beid3
-
 let lequad = Lequad
-
 let bequad = Bequad
-
 let short = if Sys.big_endian then Beshort else Leshort
-
 let long = if Sys.big_endian then Belong else Lelong
-
 let id3 = if Sys.big_endian then Beid3 else Leid3
-
 let quad = if Sys.big_endian then Bequad else Lequad
 
 let of_string = function
@@ -92,9 +77,7 @@ let pp ppf = function
 open Sigs
 
 external swap16 : int -> int = "%bswap16"
-
 external swap32 : int32 -> int32 = "%bswap_int32"
-
 external swap64 : int64 -> int64 = "%bswap_int64"
 
 let invert { bind; return } syscall =

--- a/src/size.mli
+++ b/src/size.mli
@@ -11,39 +11,22 @@ type t = private
   | Bequad
 
 val serialize : Format.formatter -> t -> unit
-
 val byte : t
-
 val leshort : t
-
 val beshort : t
-
 val short : t
-
 val lelong : t
-
 val belong : t
-
 val melong : t
-
 val long : t
-
 val leid3 : t
-
 val beid3 : t
-
 val id3 : t
-
 val lequad : t
-
 val bequad : t
-
 val quad : t
-
 val of_string : string -> t
-
 val is_size : char -> bool
-
 val pp : Format.formatter -> t -> unit
 
 open Sigs

--- a/src/sub.ml
+++ b/src/sub.ml
@@ -9,7 +9,6 @@ let v ?(start = 0) ?stop s =
   { start; stop; s }
 
 let empty = { start = 0; stop = 0; s = "" }
-
 let length { start; stop; _ } = stop - start
 
 let head ?(rev = false) { s; start; stop } =

--- a/src/test.ml
+++ b/src/test.ml
@@ -49,11 +49,8 @@ let serialize : type a. Format.formatter -> a t -> unit =
         comparison
 
 let pf = Format.fprintf
-
 let pp_int ppf = pf ppf "%d"
-
 let pp_float ppf = pf ppf "%f"
-
 let pp_string ppf = pf ppf "%S"
 
 let pp_ptime ppf v =
@@ -77,21 +74,13 @@ let pp : type a. Format.formatter -> a t -> unit =
   | Date v -> pf ppf "date:%a" (Comparison.pp pp_ptime) v
 
 let always_true = True
-
 let always_false = False
-
 let numeric w c = Numeric (w, c)
-
 let float c = Float c
-
 let str_unicode endian c = Unicode_string (endian, c)
-
 let string c = String c
-
 let length c = Length c
-
 let regex c = Regex c
-
 let date c = Date c
 
 let process : type test v. (test, v) Ty.t -> test t -> v -> v option =

--- a/src/test.mli
+++ b/src/test.mli
@@ -10,25 +10,14 @@ type 'a t = private
   | Date : Ptime.Span.t Comparison.t -> Ptime.t t
 
 val serialize : Format.formatter -> 'a t -> unit
-
 val pp : Format.formatter -> 'a t -> unit
-
 val always_true : _ t
-
 val always_false : _ t
-
 val numeric : 'w Integer.t -> 'w Comparison.t -> 'w t
-
 val float : float Comparison.t -> float t
-
 val str_unicode : [ `BE | `LE ] -> string Comparison.t -> string t
-
 val string : string Comparison.t -> string t
-
 val length : int Comparison.t -> string t
-
 val regex : Re.t Comparison.t -> Re.t t
-
 val process : ('test, 'v) Ty.t -> 'test t -> 'v -> 'v option
-
 val date : Ptime.Span.t Comparison.t -> Ptime.t t

--- a/src/tree.ml
+++ b/src/tree.ml
@@ -1,9 +1,6 @@
 let () = Printexc.record_backtrace true
-
 let ( <.> ) f g x = f (g x)
-
 let invalid_arg fmt = Format.kasprintf invalid_arg fmt
-
 let pf = Format.fprintf
 
 type 'a fmt = { fmt : 'r. unit -> ('a -> 'r, 'r) Fmt.fmt; str : Parse.message }
@@ -157,9 +154,7 @@ let offset = function
   | `Ind ind -> indirect_0 ind
 
 type _k = Ty : ('test, 'v) Ty.t -> _k
-
 type _t = Test : 'test Test.t -> _t
-
 type _f = Format : 'v fmt -> _f
 
 let calculation :
@@ -601,14 +596,9 @@ module Unsafe = struct
         { fmt = (fun () -> format_of_ty ty message); str = message } )
 
   let name ~offset name = Name (offset, name)
-
   let use ~offset ~invert name = Use { offset; invert; name }
-
   let mime str = MIME str
-
   let elt ?filename ?line operation = { operation; filename; line }
-
   let node lst = Node lst
-
   let leaf = Done
 end

--- a/src/tree.mli
+++ b/src/tree.mli
@@ -1,17 +1,12 @@
 type 'a fmt
 
 type t = private Node of (elt * t) list | Done
-
 and elt
 
 val serialize : Format.formatter -> t -> unit
-
 val serialize_elt : Format.formatter -> elt -> unit
-
 val pp : Format.formatter -> t -> unit
-
 val depth : t -> int
-
 val weight : t -> int
 
 type operation = private
@@ -21,17 +16,11 @@ type operation = private
   | MIME : string -> operation
 
 val pp_operation : Format.formatter -> operation -> unit
-
 val serialize_operation : Format.formatter -> operation -> unit
-
 val operation : elt -> operation
-
 val fmt : 'a fmt -> unit -> ('a -> 'r, 'r) Fmt.fmt
-
 val empty : t
-
 val append : t -> ?filename:string -> ?line:int -> Parse.line -> t
-
 val merge : t -> t -> t
 
 (** / *)
@@ -45,14 +34,9 @@ module Unsafe : sig
     operation
 
   val name : offset:Offset.t -> string -> operation
-
   val use : offset:Offset.t -> invert:bool -> string -> operation
-
   val mime : string -> operation
-
   val elt : ?filename:string -> ?line:int -> operation -> elt
-
   val node : (elt * t) list -> t
-
   val leaf : t
 end

--- a/src/ty.ml
+++ b/src/ty.ml
@@ -1,9 +1,6 @@
 type default = Default
-
 type clear = Clear
-
 type unsigned = { unsigned : bool }
-
 type endian = [ `BE | `LE | `ME | `NE ]
 
 type ('test, 'v) t =
@@ -159,15 +156,10 @@ let serialize : type test v. Format.formatter -> (test, v) t -> unit =
         arithmetic
 
 let pf = Format.fprintf
-
 let pp_unsigned ppf { unsigned } = if unsigned then pf ppf "u"
-
 let pp_flag letter ppf = function true -> pf ppf "%c" letter | false -> ()
-
 let pp_int ppf = pf ppf "0x%x"
-
 let pp_int32 ppf = pf ppf "0x%lx"
-
 let pp_int64 ppf = pf ppf "0x%Lx"
 
 let pp_ptime ppf v =
@@ -284,9 +276,7 @@ let pp : type test v. Format.formatter -> (test, v) t -> unit =
         (Arithmetic.pp pp_ptime) arithmetic
 
 let default : (default, default) t = Default
-
 let offset : (int64, int64) t = Offset
-
 let clear : (clear, clear) t = Clear
 
 let regex ?(case_insensitive = false) ?(start = false) ?(limit = 8192L) kind =
@@ -323,7 +313,6 @@ let with_pattern pattern = function
   | t -> t
 
 let str_unicode endian = Unicode_string endian
-
 let system_endian = if Sys.big_endian then `BE else `LE
 
 let numeric :
@@ -374,15 +363,11 @@ let indirect v = Indirect v
 open Sigs
 
 let ( <.> ) f g x = f (g x)
-
 let newline = "\n" (* TODO: windows *)
 
 let ok x = Ok x
-
 let of_option ~error = function Some x -> Ok x | None -> Error (error ())
-
 let reword_error f = function Ok x -> Ok x | Error err -> Error (f err)
-
 let id x = x
 
 let read_float ({ bind; return } as scheduler) syscall fd endian =

--- a/src/ty.mli
+++ b/src/ty.mli
@@ -1,9 +1,6 @@
 type default = Default
-
 type clear = Clear
-
 type unsigned = { unsigned : bool }
-
 type endian = [ `BE | `LE | `ME | `NE ]
 
 type ('test, 'v) t = private
@@ -47,15 +44,10 @@ type ('test, 'v) t = private
       -> (Ptime.t, string) t
 
 val serialize : Format.formatter -> ('test, 'v) t -> unit
-
 val pp : Format.formatter -> ('test, 'v) t -> unit
-
 val pp_of_result : ('test, 'v) t -> Format.formatter -> 'v -> unit
-
 val default : (default, default) t
-
 val offset : (int64, int64) t
-
 val clear : (clear, clear) t
 
 val regex :
@@ -79,9 +71,7 @@ val search :
   (string, string) t
 
 val with_range : int64 -> (string, string) t -> (string, string) t
-
 val with_pattern : string -> (string, string) t -> (string, string) t
-
 val str_unicode : [ `BE | `LE ] -> (string, string) t
 
 val numeric :

--- a/standalone/generate.ml
+++ b/standalone/generate.ml
@@ -53,7 +53,6 @@ let run database output =
   close_out oc
 
 let database = ref None
-
 let output = ref None
 
 let anonymous_argument v =
@@ -70,7 +69,6 @@ let spec =
   ]
 
 let exit_success = 0
-
 let exit_failure = 1
 
 let () =

--- a/string/conan_string.ml
+++ b/string/conan_string.ml
@@ -7,7 +7,6 @@ struct
   type t
 
   external prj : ('a, t) io -> 'a S.t = "%identity"
-
   external inj : 'a S.t -> ('a, t) io = "%identity"
 end
 
@@ -20,18 +19,14 @@ let caml =
   { bind = (fun x f -> f (prj x)); return = (fun x -> inj x) }
 
 external get_uint16 : string -> int -> int = "%caml_string_get16"
-
 external get_uint32 : string -> int -> int32 = "%caml_string_get32"
-
 external get_uint64 : string -> int -> int64 = "%caml_string_get64"
 
 module Str = struct
   type t = { mutable seek : int; contents : string; tmp : bytes }
 
   let openfile str = { seek = 0; contents = str; tmp = Bytes.create 80 }
-
   let _max_int = Int64.of_int max_int
-
   let _min_int = Int64.of_int min_int
 
   let seek t offset seek =

--- a/unix/conan_unix.ml
+++ b/unix/conan_unix.ml
@@ -10,7 +10,6 @@ struct
   type t
 
   external prj : ('a, t) io -> 'a S.t = "%identity"
-
   external inj : 'a S.t -> ('a, t) io = "%identity"
 end
 
@@ -23,9 +22,7 @@ let unix =
   { bind = (fun x f -> f (prj x)); return = (fun x -> inj x) }
 
 external get_uint16 : string -> int -> int = "%caml_string_get16"
-
 external get_uint32 : string -> int -> int32 = "%caml_string_get32"
-
 external get_uint64 : string -> int -> int64 = "%caml_string_get64"
 
 module File = struct


### PR DESCRIPTION
This is a preview of the not-yet-released `ocamlformat.0.20.0`, please wait until the package is published in opam to merge this PR. The output is still likely to slightly change before the package is released.
The changes are due to:
- `module-item-spacing` is now set to `compact` for the default profile
- `module-item-spacing` is now correctly applied to mutually recursive type definitions