### PR TITLE
Fix how we can recognize an HTML file

### DIFF
--- a/bin/file.ml
+++ b/bin/file.ml
@@ -64,4 +64,6 @@ let () =
       let fmt = if !mime then `MIME else `Usual in
       match run ~fmt filename with
       | Ok () -> exit exit_success
-      | Error err -> Format.eprintf "%s: %a.\n%!" Sys.argv.(0) pp_error err)
+      | Error err ->
+          Format.eprintf "%s: %a.\n%!" Sys.argv.(0) pp_error err;
+          exit 1)

--- a/src/test.ml
+++ b/src/test.ml
@@ -145,7 +145,14 @@ let process : type test v. (test, v) Ty.t -> test t -> v -> v option =
           let a = Buffer.contents buf in
           if Comparison.process_string a c then Some a else None
       | _ -> None)
-  | Search _, String c -> if Comparison.process_string a c then Some a else None
+  | Search _, String c ->
+      let a' = Comparison.value c in
+      let a' =
+        if String.length a > String.length a' then
+          String.sub a 0 (String.length a')
+        else a
+      in
+      if Comparison.process_string a' c then Some a else None
   | Regex { case_insensitive; _ }, Regex c -> (
       let re = Comparison.value c in
       let re = if case_insensitive then Re.no_case re else re in

--- a/test/file.t
+++ b/test/file.t
@@ -14,3 +14,6 @@ Tests the file command
   $ tar cf tarball.tar tarball
   $ RES=$(CONAN=../database/ conan.file --mime tarball.tar)
   $ test "$RES" = "application/x-gtar" || test "$RES" = "application/x-ustar"
+  $ echo "<html><h1>Hello World!</h1></html>" > index.html
+  $ CONAN=../database/ conan.file --mime index.html
+  text/html


### PR DESCRIPTION
The test between `Search` and `String` wants to pick something like 4096 bytes but apply the comparison only on few bytes. This fix allows us to recognize a HTML document.