### PR TITLE
Fix the support of OCaml 5

### DIFF
--- a/light/dune
+++ b/light/dune
@@ -14,4 +14,4 @@
   %{bin:conan.serialize}
   (source_tree ../database))
  (action
-  (run %{ocaml} %{gen} ../database -o .)))
+  (run %{ocaml} -I +unix %{gen} ../database -o .)))

--- a/src/pps.ml
+++ b/src/pps.ml
@@ -1,12 +1,12 @@
 let char_to_int : char Fmt.Hmap.Key.key = Fmt.Hmap.Key.create ()
 
 let pp_char_to_int ?padding ?precision ppf v =
-  Fmt.pp_int ~conv:Fmt.Conv_d ?padding ?precision ppf (Char.code v)
+  Fmt.pp_int ~unsigned:false ~conv:Fmt.Conv_d ?padding ?precision ppf (Char.code v)
 
 let int32_to_int : int32 Fmt.Hmap.Key.key = Fmt.Hmap.Key.create ()
 
 let pp_int32_to_int ?padding ?precision ppf v =
-  Fmt.pp_int32 ~conv:Fmt.Conv_d ?padding ?precision ppf v
+  Fmt.pp_int32 ~unsigned:false ~conv:Fmt.Conv_d ?padding ?precision ppf v
 
 let v =
   let open Fmt.Hmap in

--- a/standalone/dune
+++ b/standalone/dune
@@ -14,4 +14,4 @@
   %{bin:conan.serialize}
   (source_tree ../database))
  (action
-  (run %{ocaml} %{gen} ../database -o .)))
+  (run %{ocaml} -I +unix %{gen} ../database -o .)))


### PR DESCRIPTION
OCaml 5 has a new random number generator which catches a case where we want to evaluate a branch with `%u`. This PR implements the `%u` into our _formatter_.