### PR TITLE
Add "-p" name to dune install invocation

### DIFF
--- a/conan-cli.opam
+++ b/conan-cli.opam
@@ -35,7 +35,7 @@ conflicts: ["ocaml-option-flambda"]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "install" "--create-install-files" name]
+  ["dune" "install" "-p" name "--create-install-files" name]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/conan.git"

--- a/conan-database.opam
+++ b/conan-database.opam
@@ -19,7 +19,7 @@ conflicts: ["ocaml-option-flambda"]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "install" "--create-install-files" name]
+  ["dune" "install" "-p" name "--create-install-files" name]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/dinosaure/conan.git"

--- a/conan-lwt.opam
+++ b/conan-lwt.opam
@@ -25,7 +25,7 @@ conflicts: ["ocaml-option-flambda"]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "install" "--create-install-files" name]
+  ["dune" "install" "-p" name "--create-install-files" name]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/conan.git"

--- a/conan-unix.opam
+++ b/conan-unix.opam
@@ -24,7 +24,7 @@ conflicts: ["ocaml-option-flambda"]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "install" "--create-install-files" name]
+  ["dune" "install" "-p" name "--create-install-files" name]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/conan.git"

--- a/conan.opam
+++ b/conan.opam
@@ -34,7 +34,7 @@ conflicts: ["ocaml-option-flambda"]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "install" "--create-install-files" name]
+  ["dune" "install" "-p" name "--create-install-files" name]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/conan.git"


### PR DESCRIPTION
Fixes #19.

```
reynir@spurv:~/workspace/conan$ git checkout master 
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
reynir@spurv:~/workspace/conan$ opam install .
[NOTE] Package conan is currently pinned to git+file:///home/reynir/workspace/conan#inshallah-opam-fix (version 0.0.2).
conan is now pinned to git+file:///home/reynir/workspace/conan#master (version 0.0.2)
[NOTE] Package conan-unix is currently pinned to git+file:///home/reynir/workspace/conan#inshallah-opam-fix (version 0.0.2).
conan-unix is now pinned to git+file:///home/reynir/workspace/conan#master (version 0.0.2)
[NOTE] Package conan-lwt is currently pinned to git+file:///home/reynir/workspace/conan#inshallah-opam-fix (version 0.0.2).
conan-lwt is now pinned to git+file:///home/reynir/workspace/conan#master (version 0.0.2)
[NOTE] Package conan-database is currently pinned to git+file:///home/reynir/workspace/conan#inshallah-opam-fix (version 0.0.2).
conan-database is now pinned to git+file:///home/reynir/workspace/conan#master (version 0.0.2)
[NOTE] Package conan-cli is currently pinned to git+file:///home/reynir/workspace/conan#inshallah-opam-fix (version 0.0.2).
conan-cli is now pinned to git+file:///home/reynir/workspace/conan#master (version 0.0.2)
[NOTE] Ignoring uncommitted changes in /home/reynir/workspace/conan (`--working-dir' not active).
[NOTE] Ignoring uncommitted changes in /home/reynir/workspace/conan (`--working-dir' not active).
[NOTE] Ignoring uncommitted changes in /home/reynir/workspace/conan (`--working-dir' not active).
[conan.0.0.2] synchronised (no changes)
[conan-cli.0.0.2] synchronised (no changes)
[conan-database.0.0.2] synchronised (no changes)
[NOTE] Ignoring uncommitted changes in /home/reynir/workspace/conan (`--working-dir' not active).
[NOTE] Ignoring uncommitted changes in /home/reynir/workspace/conan (`--working-dir' not active).
[conan-lwt.0.0.2] synchronised (no changes)
[conan-unix.0.0.2] synchronised (no changes)
The following actions will be performed:
  ↻ recompile conan          0.0.2*
  ↻ recompile conan-unix     0.0.2*
  ↻ recompile conan-lwt      0.0.2*
  ↻ recompile conan-database 0.0.2*
  ↻ recompile conan-cli      0.0.2*
===== ↻ 5 =====

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
⬇ retrieved conan.0.0.2  (no changes)
⬇ retrieved conan-cli.0.0.2  (no changes)
⬇ retrieved conan-database.0.0.2  (no changes)
⬇ retrieved conan-lwt.0.0.2  (no changes)
⬇ retrieved conan-unix.0.0.2  (no changes)
[ERROR] The compilation of conan.0.0.2 failed at "dune install --create-install-files conan".

#=== ERROR while compiling conan.0.0.2 ========================================#
# context     2.1.3 | linux/x86_64 | ocaml-system.4.14.0 | pinned(git+file:///home/reynir/workspace/conan#master#fb144c77)
# path        ~/workspace/conan/_opam/.opam-switch/build/conan.0.0.2
# command     ~/.opam/opam-init/hooks/sandbox.sh build dune install --create-install-files conan
# exit-code   2
# env-file    ~/.opam/log/conan-236732-20c5aa.env
# output-file ~/.opam/log/conan-236732-20c5aa.out
### output ###
# [...]
# Fatal error: exception Sys_error("_build/.filesystem-clock: Read-only file system")
# Raised by primitive operation at Stdlib.open_out_gen in file "stdlib.ml", line 331, characters 29-55
# Called from Stdune__io.Make.with_file_out in file "otherlibs/stdune/io.ml", line 102, characters 17-43
# Called from Dune_engine__cached_digest.get_current_filesystem_time in file "src/dune_engine/cached_digest.ml", line 80, characters 2-38
# Called from Dune_engine__cached_digest.delete_very_recent_entries in file "src/dune_engine/cached_digest.ml", line 94, characters 12-42
# Called from Dune_engine__cached_digest.dump.(fun) in file "src/dune_engine/cached_digest.ml", line 117, characters 8-37
# Called from Stdune__exn.protectx in file "otherlibs/stdune/exn.ml", line 12, characters 8-11
# Re-raised at Stdune__exn.protectx in file "otherlibs/stdune/exn.ml", line 18, characters 4-11
# Called from Stdlib.at_exit.new_exit in file "stdlib.ml", line 560, characters 59-63
# Called from Stdlib.do_at_exit in file "stdlib.ml" (inlined), line 566, characters 20-61
# Called from Stdlib.exit in file "stdlib.ml", line 569, characters 2-15
# Called from Main in file "bin/main.ml", line 100, characters 4-20



<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
┌─ The following actions failed
│ λ build conan 0.0.2
└─ 
╶─ No changes have been performed
reynir@spurv:~/workspace/conan$ git log -n1
commit fb144c7785ff0aa4ec6d8c87e58ca2a0c2d328db (HEAD -> master, origin/master, origin/HEAD)
Merge: 69b871d af6ed44
Author: Calascibetta Romain <romain.calascibetta@gmail.com>
Date:   Fri Dec 23 13:04:24 2022 +0100

    Merge pull request #22 from mirage/ocamlformat
    
    Apply ocamlformat.0.24.1
reynir@spurv:~/workspace/conan$ git checkout inshallah-opam-fix 
Switched to branch 'inshallah-opam-fix'
reynir@spurv:~/workspace/conan$ opam install .
[NOTE] Package conan is currently pinned to git+file:///home/reynir/workspace/conan#master (version 0.0.2).
conan is now pinned to git+file:///home/reynir/workspace/conan#inshallah-opam-fix (version 0.0.2)
[NOTE] Package conan-unix is currently pinned to git+file:///home/reynir/workspace/conan#master (version 0.0.2).
conan-unix is now pinned to git+file:///home/reynir/workspace/conan#inshallah-opam-fix (version 0.0.2)
[NOTE] Package conan-lwt is currently pinned to git+file:///home/reynir/workspace/conan#master (version 0.0.2).
conan-lwt is now pinned to git+file:///home/reynir/workspace/conan#inshallah-opam-fix (version 0.0.2)
[NOTE] Package conan-database is currently pinned to git+file:///home/reynir/workspace/conan#master (version 0.0.2).
conan-database is now pinned to git+file:///home/reynir/workspace/conan#inshallah-opam-fix (version 0.0.2)
[NOTE] Package conan-cli is currently pinned to git+file:///home/reynir/workspace/conan#master (version 0.0.2).
conan-cli is now pinned to git+file:///home/reynir/workspace/conan#inshallah-opam-fix (version 0.0.2)
[NOTE] Ignoring uncommitted changes in /home/reynir/workspace/conan (`--working-dir' not active).
[NOTE] Ignoring uncommitted changes in /home/reynir/workspace/conan (`--working-dir' not active).
[NOTE] Ignoring uncommitted changes in /home/reynir/workspace/conan (`--working-dir' not active).
[conan.0.0.2] synchronised (git+file:///home/reynir/workspace/conan#inshallah-opam-fix)
[conan-cli.0.0.2] synchronised (git+file:///home/reynir/workspace/conan#inshallah-opam-fix)
[conan-database.0.0.2] synchronised (git+file:///home/reynir/workspace/conan#inshallah-opam-fix)
[NOTE] Ignoring uncommitted changes in /home/reynir/workspace/conan (`--working-dir' not active).
[NOTE] Ignoring uncommitted changes in /home/reynir/workspace/conan (`--working-dir' not active).
[conan-lwt.0.0.2] synchronised (git+file:///home/reynir/workspace/conan#inshallah-opam-fix)
[conan-unix.0.0.2] synchronised (git+file:///home/reynir/workspace/conan#inshallah-opam-fix)
The following actions will be performed:
  ↻ recompile conan          0.0.2*
  ↻ recompile conan-unix     0.0.2*
  ↻ recompile conan-lwt      0.0.2*
  ↻ recompile conan-database 0.0.2*
  ↻ recompile conan-cli      0.0.2*
===== ↻ 5 =====

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
⬇ retrieved conan.0.0.2  (no changes)
⬇ retrieved conan-cli.0.0.2  (no changes)
⬇ retrieved conan-database.0.0.2  (no changes)
⬇ retrieved conan-lwt.0.0.2  (no changes)
⬇ retrieved conan-unix.0.0.2  (no changes)
⊘ removed   conan-cli.0.0.2
⊘ removed   conan-database.0.0.2
⊘ removed   conan-lwt.0.0.2
⊘ removed   conan-unix.0.0.2
⊘ removed   conan.0.0.2
∗ installed conan.0.0.2
∗ installed conan-lwt.0.0.2
∗ installed conan-unix.0.0.2
∗ installed conan-database.0.0.2
∗ installed conan-cli.0.0.2
Done.
```