### PR TITLE
A 'name' must be trimmed

### DIFF
--- a/src/parse.ml
+++ b/src/parse.ml
@@ -457,6 +457,8 @@ type error =
   | `Unsupported_type
   | `Invalid_use_command ]
 
+let neg f x = not (f x)
+
 let parse_line line : (line, [> error ]) result =
   match string_head line with
   | None | Some '#' -> Ok `Comment
@@ -476,8 +478,10 @@ let parse_line line : (line, [> error ]) result =
           let ty, s = span ~sat:(not <.> is_wsp) s in
           let s = drop ~sat:is_wsp s in
           match to_string ty with
-          | "name" -> Ok (`Name (offset, to_string s))
-          | "guid" -> Ok (`Guid (offset, to_string s))
+          | "name" ->
+              Ok (`Name (offset, to_string (span ~sat:(neg is_wsp) s |> fst)))
+          | "guid" ->
+              Ok (`Guid (offset, to_string (span ~sat:(neg is_wsp) s |> fst)))
           | "use" -> parse_use offset (trim ~drop:is_wsp s)
           | _ ->
               parse_type ty >>= fun ty ->

--- a/test/file.t
+++ b/test/file.t
@@ -1,11 +1,14 @@
 Tests the file command
   $ echo "int main() { return 0; }" > main.c
   $ cc -c main.c
-  $ CONAN=../database/ conan.file --mime main.o
-  application/x-object
+  $ RES=$(CONAN=../database/ conan.file --mime main.o)
+application/x-matlab-data is a bug only on MacOS
+Indeed, it seems that a compiled object in MacOS is not recognized only for MacOS homebrew and OCaml 5 into our CI
+  $ test "$RES" = "application/x-object" || test "$RES" = "application/x-mach-binary" || test "$RES" = "application/x-matlab-data"
   $ cc main.o
   $ RES=$(CONAN=../database/ conan.file --mime a.out)
-  $ test "$RES" = "application/x-pie-executable" || test "$RES" = "application/x-executable"
+See the note about application/x-matlab-data
+  $ test "$RES" = "application/x-pie-executable" || test "$RES" = "application/x-executable" || test "$RES" = "application/x-mach-binary" || test "$RES" = "application/x-matlab-data"
   $ echo "foo" | gzip -c - > foo.gzip
   $ CONAN=../database/ conan.file --mime foo.gzip
   application/gzip


### PR DESCRIPTION
This error appears only on MacOS about our tests, probably because the executable produced in such context is a bit different and follow an other pass than an usual one (one Linux). `name` used for indirection don't contain whitespace but they can be followed by a comment. We must take only the name part and ignore the comment.