### PR TITLE
process.ml: fix type annotation

### DIFF
--- a/src/process.ml
+++ b/src/process.ml
@@ -28,7 +28,7 @@ let process :
     Metadata.t ->
     Tree.operation ->
     ( ( int64 * Metadata.t,
-        [> `Syscall of error | `Invalid_test | `No_process ] )
+        [> `Syscall of error | `Invalid_date | `Invalid_test | `No_process | `Not_found] )
       result,
       s )
     io =


### PR DESCRIPTION
OCaml 5.1 is stricter when mixing explicitly polymorphic annotation and anonymous row variables. In particular, it is no longer possible to elide some of the constructors of the polymorphic variants.